### PR TITLE
Fix: mypage guard 반영 및 history 점수누적 논리오류 수정

### DIFF
--- a/website_be/src/mypage/mypage.controller.ts
+++ b/website_be/src/mypage/mypage.controller.ts
@@ -1,37 +1,47 @@
-import { Body, Controller, Get, Param, Put } from "@nestjs/common";
+import { Body, Controller, Get, Param, Put, Req, UseGuards} from "@nestjs/common";
 import { MypageService } from "./service/mypage.service";
-import { ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
+import { ApiOperation, ApiResponse, ApiTags, ApiBearerAuth } from "@nestjs/swagger";
 import { MypageProfileResponseDto } from "./dto/response/mypage-profile.response.dto";
 import { MypageHistoryResponseDto } from "./dto/response/mypage-history.response.dto";
 import { User } from "src/user/entities/user.entity";
 import { UpdateUserDto } from "./dto/request/mypage-profile.request.dto";
+import { JwtAuthGuard } from "src/auth/security/jwt.guard";
 
 @ApiTags("Mypage")
 @Controller("mypage")
 export class MypageController {
   constructor(private readonly mypageService: MypageService) {}
 
-  @Get(":userId/profile")
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('token') 
+  @Get("profile") 
   @ApiOperation({ summary: "프로필 조회" })
   @ApiResponse({ type: MypageProfileResponseDto })
-  async getProfile(@Param("userId") userId: number) {
-    return this.mypageService.getProfile(userId);
+  async getProfile(@Req() req): Promise<MypageProfileResponseDto> {
+    const { user } = req;
+    return this.mypageService.getProfile(user.id);
   }
 
-  @Get(":userId/history")
+  @UseGuards(JwtAuthGuard) 
+  @ApiBearerAuth('token')
+  @Get("history")
   @ApiOperation({ summary: "포인트 히스토리 조회" })
   @ApiResponse({ type: [MypageHistoryResponseDto] })
-  async getHistory(@Param("userId") userId: number) {
-    return this.mypageService.getHistory(userId);
+  async getHistory(@Req() req): Promise<MypageHistoryResponseDto[]> {
+    const { user } = req;
+    return this.mypageService.getHistory(user.id);
   }
 
-  @Put(':userId/profile') 
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('token')
+  @Put("profile")
   @ApiOperation({ summary: "프로필 정보수정" })
   @ApiResponse({ status: 200, description: '사용자 정보가 성공적으로 업데이트되었습니다.', type: User })
   async updateProfile(
-    @Param('userId') userId: number,
+    @Req() req,
     @Body() updateUserDto: UpdateUserDto
   ): Promise<User> {
-    return this.mypageService.updateUser(userId, updateUserDto);
+    const { user } = req; // Guard에서 인증된 사용자 정보
+    return this.mypageService.updateUser(user.id, updateUserDto); // 인증된 사용자 ID 사용
   }
 }

--- a/website_be/src/mypage/service/mypage.service.ts
+++ b/website_be/src/mypage/service/mypage.service.ts
@@ -47,12 +47,13 @@ export class MypageService {
   }
   
   
-  
   async getHistory(userId: number): Promise<MypageHistoryResponseDto[]> {
     const histories = await this.historyRepository.findByUserId(userId);
     let accumulatedPoints = 0;
-
-    return histories.map((history) => {
+  
+    const sortedHistories = histories.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  
+    const result = sortedHistories.map((history) => {
       accumulatedPoints += history.pointChange;
       return {
         date: history.createdAt.toISOString().split("T")[0],
@@ -61,8 +62,10 @@ export class MypageService {
         reason: history.reason,
       };
     });
+  
+    return result.reverse();
   }
-
+  
   
   async updateUser(userId: number, updateUserDto: UpdateUserDto): Promise<User> {
     const user = await this.userRepository.findById(userId);


### PR DESCRIPTION
## Description 
id param 호출 형식을 guard user.id로 전환
점수 누적이 과거부터 되지 않는 오류 발견 
-> 과거부터 누적되도록 로직 수정 완료

## Related Issues
이제 이미지만 버킷에서 조회, 수정되면 끝!